### PR TITLE
fix: Resolve white screen issue on GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Build
         run: bun run build
+        env:
+          VITE_BASE_URL: /${{ github.event.repository.name }}/
 
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,7 @@ const App = () => (
     <TooltipProvider>
       <Toaster />
       <Sonner />
-      <BrowserRouter>
+      <BrowserRouter basename={import.meta.env.BASE_URL}>
         <Routes>
           <Route path="/" element={<Index />} />
           <Route path="/upload" element={<Upload />} />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,13 +4,9 @@ import path from "path";
 import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
-export default defineConfig(({ mode, command }) => {
-  const base = command === 'build' && mode === 'production'
-    ? '/vite_react_shadcn_ts/'
-    : '/';
-
+export default defineConfig(({ mode }) => {
   return {
-    base,
+    base: process.env.VITE_BASE_URL || '/',
     server: {
       host: "::",
       port: 8080,


### PR DESCRIPTION
This commit fixes the blank page issue when the application is deployed to GitHub Pages. The problem was caused by an incorrect `base` path configuration in Vite and a missing `basename` in React Router.

- `vite.config.ts` is updated to use a `VITE_BASE_URL` environment variable for the `base` path. This makes the configuration dynamic and removes the previous hardcoded value.
- The `.github/workflows/deploy.yml` workflow is updated to dynamically set this `VITE_BASE_URL` variable based on the repository's name.
- `src/App.tsx` is updated to pass the correct `basename` to the `BrowserRouter`, using Vite's `import.meta.env.BASE_URL`. This synchronizes the client-side router with the application's base path.

These changes ensure that the application assets are loaded correctly and that routing works as expected in the GitHub Pages environment.