### PR TITLE
fix: Correct asset paths for PDF viewer on deployment

### DIFF
--- a/src/components/PdfViewer.tsx
+++ b/src/components/PdfViewer.tsx
@@ -2,7 +2,7 @@ import { Document, Page, pdfjs } from "react-pdf";
 import React, { useState, useRef, useEffect } from "react";
 
 // Ensure pdfjs worker is set (important for react-pdf in TypeScript)
-pdfjs.GlobalWorkerOptions.workerSrc = `//unpkg.com/pdfjs-dist@${pdfjs.version}/build/pdf.worker.min.js`;
+pdfjs.GlobalWorkerOptions.workerSrc = `${import.meta.env.BASE_URL}pdf.worker.min.mjs`;
 
 interface PDFViewerProps {
   fileUrl: string;

--- a/src/pages/DocumentProcessing.tsx
+++ b/src/pages/DocumentProcessing.tsx
@@ -7,10 +7,7 @@ import { Progress } from "@/components/ui/progress";
 import { Send, Users, Building2, Mail, Phone } from "lucide-react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { useToast } from "@/hooks/use-toast";
-import { Document, pdfjs } from "react-pdf";
 import PDFViewer from "@/components/PdfViewer";
-// Use the .mjs worker from public folder
-pdfjs.GlobalWorkerOptions.workerSrc = "/pdf.worker.min.mjs";
 
 const DocumentProcessing = () => {
   const [searchParams] = useSearchParams();
@@ -72,7 +69,11 @@ const DocumentProcessing = () => {
         {!isProcessed ? (
           <div className="flex flex-row h-full gap-6 items-center">
             <div className="w-1/2 h-full">
-              <PDFViewer fileUrl="assets/03_Lieferantenstammdaten.pdf" />
+              <PDFViewer
+                fileUrl={`${
+                  import.meta.env.BASE_URL
+                }assets/03_Lieferantenstammdaten.pdf`}
+              />
             </div>
             <div className="w-1/2 h-full">
               <Card className="shadow-card">
@@ -107,7 +108,11 @@ const DocumentProcessing = () => {
           <div className="flex-1 flex flex-col" style={{ height: "100%" }}>
             <div className="flex-1 flex gap-6">
               <div className="w-1/2" style={{ overflow: "hidden" }}>
-                <PDFViewer fileUrl="assets/03_Lieferantenstammdaten editted.pdf" />
+                <PDFViewer
+                  fileUrl={`${
+                    import.meta.env.BASE_URL
+                  }assets/03_Lieferantenstammdaten editted.pdf`}
+                />
               </div>
 
               {/* Right - Analysis Panel */}


### PR DESCRIPTION
This commit resolves the "Failed to load PDF file" error that occurred on the deployed GitHub Pages site. The issue was caused by hardcoded paths to the PDF worker script and the PDF documents themselves.

- In `src/components/PdfViewer.tsx`, the PDF worker source is changed from a hardcoded CDN URL to a local file (`pdf.worker.min.mjs`). The path is constructed dynamically using `import.meta.env.BASE_URL` to ensure it works in all environments.
- A redundant and incorrect worker path configuration is removed from `src/pages/DocumentProcessing.tsx`.
- In `src/pages/DocumentProcessing.tsx`, the hardcoded `fileUrl` props for the `PDFViewer` components are updated to be prepended with `import.meta.env.BASE_URL`, ensuring the PDF documents can be found on the deployed site.