### PR TITLE
fix: Ensure PDF files are bundled for production

### DIFF
--- a/src/pages/DocumentProcessing.tsx
+++ b/src/pages/DocumentProcessing.tsx
@@ -8,6 +8,8 @@ import { Send, Users, Building2, Mail, Phone } from "lucide-react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { useToast } from "@/hooks/use-toast";
 import PDFViewer from "@/components/PdfViewer";
+import pdfFile from "../../assets/03_Lieferantenstammdaten.pdf";
+import pdfFileEditted from "../../assets/03_Lieferantenstammdaten editted.pdf";
 
 const DocumentProcessing = () => {
   const [searchParams] = useSearchParams();
@@ -69,11 +71,7 @@ const DocumentProcessing = () => {
         {!isProcessed ? (
           <div className="flex flex-row h-full gap-6 items-center">
             <div className="w-1/2 h-full">
-              <PDFViewer
-                fileUrl={`${
-                  import.meta.env.BASE_URL
-                }assets/03_Lieferantenstammdaten.pdf`}
-              />
+              <PDFViewer fileUrl={pdfFile} />
             </div>
             <div className="w-1/2 h-full">
               <Card className="shadow-card">
@@ -108,11 +106,7 @@ const DocumentProcessing = () => {
           <div className="flex-1 flex flex-col" style={{ height: "100%" }}>
             <div className="flex-1 flex gap-6">
               <div className="w-1/2" style={{ overflow: "hidden" }}>
-                <PDFViewer
-                  fileUrl={`${
-                    import.meta.env.BASE_URL
-                  }assets/03_Lieferantenstammdaten editted.pdf`}
-                />
+                <PDFViewer fileUrl={pdfFileEditted} />
               </div>
 
               {/* Right - Analysis Panel */}


### PR DESCRIPTION
This commit resolves the persistent "Failed to load PDF file" error on the deployed site.

The root cause was that the PDF files were referenced as simple strings in the application code. This prevented Vite's build process from recognizing them as dependencies, so they were never copied into the production `dist` directory and were unavailable on the deployed site.

The fix involves changing `src/pages/DocumentProcessing.tsx` to directly `import` the PDF files. This makes Vite aware of the files as assets, ensuring they are correctly processed, bundled, and placed in the build output with the correct URLs. The `PDFViewer` components are updated to use the variables from these imports instead of a manually constructed string path.